### PR TITLE
Remove studies submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ContractNet"]
-    path = studies/ContractNet
-    url = git@github.com:GageDeZoort/ContractNet.git


### PR DESCRIPTION
Fixes #196 

This also helps with issues after putting `gnn_tracking` as a dependency for `gnn_tracking_hpo`