### PR TITLE
Avoid specifying explicit but too large 'stop'

### DIFF
--- a/src/gnn_tracking/graph_construction/graph_builder.py
+++ b/src/gnn_tracking/graph_construction/graph_builder.py
@@ -349,6 +349,12 @@ class GraphBuilder:
 
     def process(self, start=0, stop=1):
         available_files = os.listdir(self.indir)
+        if stop is not None and stop > len(available_files):
+            # to avoid tracking wrong hyperparameters
+            raise ValueError(
+                f"stop={stop} is larger than the number of files "
+                f"({len(available_files)})"
+            )
         considered_files = available_files[start:stop]
         logger.info(
             "Loading %d graphs (out of %d available).",
@@ -421,6 +427,11 @@ def load_graphs(in_dir: str | os.PathLike, *, start=0, stop=None):
     """
     in_dir = Path(in_dir)
     available_files = list(in_dir.glob("*.pt"))
+    if stop is not None and stop > len(available_files):
+        # to avoid tracking wrong hyperparameters
+        raise ValueError(
+            f"stop={stop} is larger than the number of files ({len(available_files)})"
+        )
     considered_files = available_files[start:stop]
     logger.info(
         "Loading %d graphs (out of %d available).",

--- a/src/gnn_tracking/preprocessing/point_cloud_builder.py
+++ b/src/gnn_tracking/preprocessing/point_cloud_builder.py
@@ -271,6 +271,11 @@ class PointCloudBuilder:
         Returns:
 
         """
+        if stop is not None and stop > len(self.prefixes):
+            # to avoid tracking wrong hyperparameters
+            raise ValueError(
+                f"stop={stop} is larger than the number of files ({len(self.prefixes)})"
+            )
         for f in self.prefixes[start:stop]:
             self.logger.debug(f"Processing {f}")
 


### PR DESCRIPTION
This is to avoid tracking incorrect hyperparameters for the number of
training graphs
