### PR TITLE
use torch JIT

### DIFF
--- a/src/gnn_tracking/metrics/test_losses.py
+++ b/src/gnn_tracking/metrics/test_losses.py
@@ -11,7 +11,7 @@ from typing_extensions import TypeAlias
 from gnn_tracking.metrics.losses import (
     BackgroundLoss,
     ObjectLoss,
-    PotentialLoss,
+    _condensation_loss,
     binary_focal_loss,
 )
 
@@ -46,7 +46,9 @@ td2 = generate_test_data(20, n_particles=3, rng=np.random.default_rng(seed=0))
 
 
 def get_condensation_loss(td: MockData) -> float:
-    loss_dct = PotentialLoss(q_min=0.01, radius_threshold=1)._condensation_loss(
+    loss_dct = _condensation_loss(
+        q_min=0.01,
+        radius_threshold=1,
         beta=td.beta,
         x=td.x,
         particle_id=td.particle_id,

--- a/src/gnn_tracking/metrics/test_losses.py
+++ b/src/gnn_tracking/metrics/test_losses.py
@@ -98,5 +98,9 @@ def test_focal_loss_vs_bce():
     inpt = torch.rand(10)
     target = (torch.rand(10) > 0.5).float()
     assert binary_focal_loss(inpt=inpt, target=target, alpha=0.5, gamma=0.0) == approx(
-        0.5 * binary_cross_entropy(inpt, target, reduction="mean")
+        0.5
+        * binary_cross_entropy(
+            inpt,
+            target,
+        )
     )

--- a/src/gnn_tracking/metrics/test_losses.py
+++ b/src/gnn_tracking/metrics/test_losses.py
@@ -9,8 +9,8 @@ from torch.nn.functional import binary_cross_entropy
 from typing_extensions import TypeAlias
 
 from gnn_tracking.metrics.losses import (
-    BackgroundLoss,
     ObjectLoss,
+    _background_loss,
     _condensation_loss,
     binary_focal_loss,
 )
@@ -59,11 +59,7 @@ def get_condensation_loss(td: MockData) -> float:
 
 
 def get_background_loss(td: MockData) -> float:
-    return (
-        BackgroundLoss(sb=0.1)
-        ._background_loss(beta=td.beta, particle_id=td.particle_id)
-        .item()
-    )
+    return _background_loss(sb=0.1, beta=td.beta, particle_id=td.particle_id).item()
 
 
 def get_object_loss(td: MockData, **kwargs) -> float:

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -99,7 +99,7 @@ class ResIN(nn.Module):
                     include_last_activation=True,
                 )
             else:
-                first_encoder = None
+                first_encoder = nn.Identity()
             mod.residue_encoders = nn.ModuleList([first_encoder])
             return mod
 
@@ -120,7 +120,7 @@ class ResIN(nn.Module):
                 include_last_activation=True,
             )
         else:
-            first_encoder = None
+            first_encoder = nn.Identity()
         hidden_layers = [
             InteractionNetwork(
                 node_indim=node_hidden_dim,
@@ -150,7 +150,7 @@ class ResIN(nn.Module):
                 include_last_activation=True,
             )
         else:
-            last_encoder = None
+            last_encoder = nn.Identity()
         layers = [first_layer, *hidden_layers, last_layer]
         encoders = [first_encoder, *hidden_encoders, last_encoder]
         assert len(layers) == n_layers == len(encoders)
@@ -177,12 +177,8 @@ class ResIN(nn.Module):
         hs = [h]
         for layer, re in zip(self.layers, self.residue_encoders):
             delta_h, edge_attr = layer(h, edge_index, edge_attr)
-            if re is None:
-                h_ec = h
-            else:
-                h_ec = re(h)
             h = convex_combination(
-                delta=delta_h, residue=h_ec, alpha_residue=self.alpha
+                delta=delta_h, residue=re(h), alpha_residue=self.alpha
             )
             hs.append(h)
             edge_attrs.append(edge_attr)


### PR DESCRIPTION
- Rm args for reduction/masking of 0/1s in FocalLoss
- Catch NaNs in input; remove lengthy debug logs
- JIT-compile focal loss
- JIT-compiling condensation loss
- JIT-compiling background loss
- torch-JIT compile convex combination
- Simplify logic using nn.Identity instead of None
