### PR TITLE
Replace os.path with pathlib

### DIFF
--- a/src/gnn_tracking/graph_construction/graph_builder.py
+++ b/src/gnn_tracking/graph_construction/graph_builder.py
@@ -54,8 +54,8 @@ class GraphBuilder:
             collect_data: Deprecated: Directly load the data into memory
         """
         self.indir = Path(indir)
-        os.makedirs(outdir, exist_ok=True)
         self.outdir = Path(outdir)
+        self.outdir.mkdir(parents=True, exist_ok=True)
         self.pixel_only = pixel_only
         self.redo = redo
         self.phi_slope_max = phi_slope_max
@@ -68,7 +68,7 @@ class GraphBuilder:
             [1000.0, np.pi, 1000.0, 1, 1 / 1000.0, 1 / 1000.0]
         )
         self._data_list = []
-        self.outfiles = os.listdir(outdir)
+        self.outfiles = [child.name for child in self.outdir.iterdir()]
         self.directed = directed
         self.measurement_mode = measurement_mode
         self.write_output = write_output
@@ -404,7 +404,7 @@ class GraphBuilder:
         Returns:
 
         """
-        available_files = os.listdir(self.indir)
+        available_files = [child.name for child in self.indir.iterdir()]
         if stop is not None and stop > len(available_files):
             # to avoid tracking wrong hyperparameters
             raise ValueError(

--- a/src/gnn_tracking/preprocessing/point_cloud_builder.py
+++ b/src/gnn_tracking/preprocessing/point_cloud_builder.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import collections
 import logging
-import os
 from pathlib import Path, PurePath
 from typing import Any
 
@@ -59,8 +58,8 @@ class PointCloudBuilder:
             collect_data: Collect data in memory
         """
         # create outdir if necessary
-        os.makedirs(outdir, exist_ok=True)
         self.outdir = Path(outdir)
+        self.outdir.mkdir(parents=True, exist_ok=True)
 
         self.indir = Path(indir)
         self.n_sectors = n_sectors
@@ -81,10 +80,10 @@ class PointCloudBuilder:
         self.prefixes: list[str] = []
         #: Does an output file for a given key exist?
         self.exists: dict[str, bool] = {}
-        outfiles = os.listdir(outdir)
-        for p in os.listdir(self.indir):
-            if str(p).endswith(suffix):
-                prefix = str(p).replace(suffix, "")
+        outfiles = [child.name for child in self.outdir.iterdir()]
+        for p in self.indir.iterdir():
+            if p.name.endswith(suffix):
+                prefix = p.name.replace(suffix, "")
                 evtid = int(prefix[-9:])
                 for s in range(self.n_sectors):
                     key = f"data{evtid}_s{s}.pt"

--- a/src/gnn_tracking/utils/plotting.py
+++ b/src/gnn_tracking/utils/plotting.py
@@ -23,7 +23,7 @@ class EventPlotter:
         indir: str | os.PathLike,
     ):
         self.indir = Path(indir)
-        self.infiles = os.listdir(self.indir)
+        self.infiles = [child.name for child in self.indir.iterdir()]
 
     def calc_eta(self, r, z):
         theta = np.arctan2(r, z)
@@ -83,7 +83,7 @@ class EventPlotter:
 class PointCloudPlotter:
     def __init__(self, indir: str | os.PathLike, n_sectors=64):
         self.indir = Path(indir)
-        self.infiles = os.listdir(indir)
+        self.infiles = [child.name for child in self.indir.iterdir()]
         self.n_sectors = n_sectors
         self.colors = cm.prism(np.linspace(0, 1, n_sectors))
 


### PR DESCRIPTION
## Description

As discussed in #265, this PR proposes the replacement of tools from the `os.path()` with their counterparts in the Pathlib library. 

The following functions have been replaced:
- `os.makedirs()`
- `os.listdir()`