### PR TITLE
Model restructuring

### DIFF
--- a/src/gnn_tracking/models/edge_classifier.py
+++ b/src/gnn_tracking/models/edge_classifier.py
@@ -124,7 +124,6 @@ class ECForGraphTCN(nn.Module):
         self,
         data: Data,
     ) -> Tensor:
-        # apply the edge classifier to generate edge weights
         x, edge_index, edge_attr = data.x, data.edge_index, data.edge_attr
         h_ec = self.relu(self.ec_node_encoder(x))
         edge_attr_ec = self.relu(self.ec_edge_encoder(edge_attr))
@@ -132,7 +131,6 @@ class ECForGraphTCN(nn.Module):
             h_ec, edge_index, edge_attr_ec
         )
 
-        # append edge weights as new edge features
         w_input = edge_attr_ec
         if self._use_intermediate_edge_embeddings:
             w_input = torch.cat(edge_attrs_ec, dim=1)

--- a/src/gnn_tracking/models/edge_classifier.py
+++ b/src/gnn_tracking/models/edge_classifier.py
@@ -59,8 +59,7 @@ class ECForGraphTCN(nn.Module):
         interaction_edge_dim=4,
         hidden_dim=40,
         L_ec=3,
-        alpha_ec_node: float = 0.5,
-        alpha_ec_edge: float = 0.0,
+        alpha: float = 0.5,
         residual_type="skip1",
         use_intermediate_encodings: bool = True,
         residual_kwargs: dict | None = None,
@@ -81,7 +80,7 @@ class ECForGraphTCN(nn.Module):
             hidden_dim: width of hidden layers in all perceptrons (edge and node
                 encoders, hidden dims for MLPs in object and relation networks)
             L_ec: message passing depth for edge classifier
-            alpha_ec: strength of residual connection for EC
+            alpha: strength of residual connection for EC
             residual_type: type of residual connection for EC
             use_intermediate_encodings: If true, don't only feed the final encoding of
                 the stacked interaction networks to the final MLP, but all intermediate
@@ -106,8 +105,7 @@ class ECForGraphTCN(nn.Module):
             edge_dim=interaction_edge_dim,
             object_hidden_dim=hidden_dim,
             relational_hidden_dim=hidden_dim,
-            alpha_node=alpha_ec_node,
-            alpha_edge=alpha_ec_edge,
+            alpha=alpha,
             n_layers=L_ec,
             residual_type=residual_type,
             residual_kwargs=residual_kwargs,
@@ -131,7 +129,7 @@ class ECForGraphTCN(nn.Module):
         x, edge_index, edge_attr = data.x, data.edge_index, data.edge_attr
         h_ec = self.relu(self.ec_node_encoder(x))
         edge_attr_ec = self.relu(self.ec_edge_encoder(edge_attr))
-        h_ec, edge_attr_ec, _, edge_attrs_ec = self.ec_resin(
+        h_ec, edge_attr_ec, edge_attrs_ec = self.ec_resin(
             h_ec, edge_index, edge_attr_ec
         )
 

--- a/src/gnn_tracking/models/edge_classifier.py
+++ b/src/gnn_tracking/models/edge_classifier.py
@@ -62,7 +62,7 @@ class ECForGraphTCN(nn.Module):
         alpha_ec: float = 0.5,
         residual_type="skip1",
         use_intermediate_layers: bool = True,
-        **kwargs,
+        residual_kwargs: dict | None = None,
     ):
         """Edge classification step to be used for Graph Track Condensor network
         (Graph TCN)
@@ -84,9 +84,11 @@ class ECForGraphTCN(nn.Module):
             use_intermediate_layers: If true, don't only feed the final layer of the
                 stacked interaction networks to the final MLP, but all intermediate
                 output
-            **kwargs: Passed to `build_resin`
+            residual_kwargs: Keyword arguments passed to `build_resin`
         """
         super().__init__()
+        if residual_kwargs is None:
+            residual_kwargs = {}
         self.relu = nn.ReLU()
 
         self.ec_node_encoder = MLP(
@@ -104,7 +106,7 @@ class ECForGraphTCN(nn.Module):
             alpha_edge=alpha_ec,
             n_layers=L_ec,
             residual_type=residual_type,
-            **kwargs,
+            residual_kwargs=residual_kwargs,
         )
 
         w_input_dim = interaction_edge_dim

--- a/src/gnn_tracking/models/edge_classifier.py
+++ b/src/gnn_tracking/models/edge_classifier.py
@@ -109,7 +109,10 @@ class ECForGraphTCN(nn.Module):
 
         w_input_dim = interaction_edge_dim
         if use_intermediate_layers:
-            w_input_dim *= L_ec + 1
+            if residual_type != "skip2":
+                w_input_dim *= L_ec + 1
+            else:
+                w_input_dim *= L_ec // 2 + 1
         print(f"{w_input_dim:=}, {L_ec:=}")
         self.W = MLP(input_size=w_input_dim, output_size=1, hidden_dim=hidden_dim, L=3)
         self._use_intermediate_layers = use_intermediate_layers

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -100,6 +100,7 @@ class Skip1ResidualNetwork(ResidualNetwork):
                 alpha_residue=self._alpha_edge,
             )
             xs.append(x)
+            edge_attrs.append(edge_attr)
         return x, edge_attr, xs, edge_attrs
 
 
@@ -159,6 +160,8 @@ class Skip2ResidualNetwork(ResidualNetwork):
             edge_attr = convex_combination(
                 delta=delta_edge_attr, residue=edge_attr, alpha_residue=self._alpha_edge
             )
+            xs.append(x)
+            edge_attrs.append(edge_attr)
         return x, edge_attr, xs, edge_attrs
 
 

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import math
+from abc import ABC, abstractmethod
+from typing import Any
+
 import torch
-from torch import Tensor
 from torch import Tensor as T
 from torch import nn
 from torch.nn.functional import relu
@@ -10,119 +13,57 @@ from gnn_tracking.models.interaction_network import InteractionNetwork
 
 
 @torch.jit.script
-def convex_combination(
+def _convex_combination(
     *,
     delta: T,
     residue: T,
     alpha_residue: float,
 ) -> T:
-    """Convex combination of delta and residue"""
-    # if torch.isclose(alpha_residue, 0.0):
-    #     return relu(delta)
+    """Helper function for JIT compilation"""
     assert 0 <= alpha_residue <= 1
     return alpha_residue * residue + (1 - alpha_residue) * delta
 
 
-class ResIN(nn.Module):
+def convex_combination(
+    *,
+    delta: T,
+    residue: T | None,
+    alpha_residue: float,
+) -> T:
+    """Convex combination of delta and residue"""
+    if residue is None:
+        return delta
+    if math.isclose(alpha_residue, 0.0):
+        return delta
+    return _convex_combination(
+        delta=delta, residue=residue, alpha_residue=alpha_residue
+    )
+
+
+class ResidualNetwork(ABC, nn.Module):
     def __init__(
         self,
         layers: list[nn.Module],
         *,
-        node_dim: int,
-        edge_dim: int,
         alpha_node: float = 0.5,
         alpha_edge: float = 0.5,
-        add_bn: bool = True,
     ):
         """Apply a list of layers in sequence with residual connections for the nodes.
-        Built for interaction networks, but any network that returns a node feature
-        tensor and an edge feature tensor should
-        work.
-
-        Note that a ReLu activation function is applied to the node result of the
-        layer.
+        This is an abstract base class that does not contain code for the type of
+        residual connections.
+        Use one of the subclasses below.
 
         Args:
             layers: List of layers
-            node_dim: Node feature dimension
-            edge_dim: Edge feature dimension
             alpha_node: Strength of the node embedding residual connection
             alpha_edge: Strength of the edge embedding residual connection
-            add_bn: Add batch norms
         """
         super().__init__()
-        if not len(layers) % 2 == 0:
-            raise ValueError("Only even number of layers allowed at the moment")
         self._layers = nn.ModuleList(layers)
-        if add_bn:
-            self._node_batch_norms = nn.ModuleList(
-                [nn.BatchNorm1d(node_dim) for _ in range(len(layers))]
-            )
-            self._edge_batch_norms = nn.ModuleList(
-                [nn.BatchNorm1d(edge_dim) for _ in range(len(layers))]
-            )
-        else:
-            self._node_batch_norms = nn.ModuleList(
-                [nn.Identity() for _ in range(len(layers))]
-            )
-            self._edge_batch_norms = nn.ModuleList(
-                [nn.Identity() for _ in range(len(layers))]
-            )
-
         self._alpha_node = alpha_node
         self._alpha_edge = alpha_edge
 
-    @classmethod
-    def identical_in_layers(
-        cls,
-        *,
-        node_dim: int,
-        edge_dim: int,
-        object_hidden_dim=40,
-        relational_hidden_dim=40,
-        alpha_node: float = 0.5,
-        alpha_edge: float = 0.5,
-        n_layers=1,
-        **kwargs,
-    ) -> ResIN:
-        """Create a ResIN with identical layers of interaction networks except for
-        the first and last one (different dimensions)
-
-        If the input/hidden/output dimensions for the nodes are not the same, MLPs are
-        used to map the previous output for the residual connection.
-
-        Args:
-            node_dim: Node feature dimension
-            edge_dim: Edge feature dimension
-            object_hidden_dim: Hidden dimension for the object model MLP
-            relational_hidden_dim: Hidden dimension for the relational model MLP
-            alpha_node: Strength of the node residual connection
-            alpha_edge: Strength of the edge residual connection
-            n_layers: Total number of layers
-            **kwargs: Passed on to __init__
-        """
-        layers = [
-            InteractionNetwork(
-                node_indim=node_dim,
-                edge_indim=edge_dim,
-                node_outdim=node_dim,
-                edge_outdim=edge_dim,
-                node_hidden_dim=object_hidden_dim,
-                edge_hidden_dim=relational_hidden_dim,
-            )
-            for i in range(n_layers)
-        ]
-        mod = cls(
-            layers,
-            alpha_node=alpha_node,
-            alpha_edge=alpha_edge,
-            node_dim=node_dim,
-            edge_dim=edge_dim,
-            **kwargs,
-        )
-        return mod
-
-    def forward(self, x, edge_index, edge_attr) -> tuple[Tensor, Tensor]:
+    def forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
         """Forward pass
 
         Args:
@@ -131,8 +72,74 @@ class ResIN(nn.Module):
             edge_attr: Edge features
 
         Returns:
-            node embedding, edge_embedding
+            node embedding, edge_embedding, concatenated node embeddings from all levels
+            (including x), concatenated edge embeddings from all levels (include
+            ``edge_attr``)
         """
+        return self._forward(x, edge_index, edge_attr)
+
+    @abstractmethod
+    def _forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
+        pass
+
+
+class Skip1ResidualNetwork(ResidualNetwork):
+    def _forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
+        xs = [x]
+        edge_attrs = [edge_attr]
+        for layer in self._layers:
+            delta_x, delta_edge_attr = layer(x, edge_index, edge_attr)
+            x = convex_combination(
+                delta=relu(delta_x),
+                residue=x,
+                alpha_residue=self._alpha_node,
+            )
+            edge_attr = convex_combination(
+                delta=relu(delta_edge_attr),
+                residue=edge_attr,
+                alpha_residue=self._alpha_edge,
+            )
+            xs.append(x)
+        return x, edge_attr, xs, edge_attrs
+
+
+class Skip2ResidualNetwork(ResidualNetwork):
+    def __init__(
+        self,
+        layers: list[nn.Module],
+        *,
+        node_dim: int,
+        edge_dim: int,
+        add_bn: bool = True,
+        **kwargs,
+    ):
+        """Residual network with skip connections every two layers.
+
+        Args:
+            layers: List of layers
+            node_dim: Node feature dimension
+            edge_dim: Edge feature dimension
+            add_bn: Add batch norms
+            **kwargs: Arguments to `ResidualNetwork`
+        """
+        if not len(layers) % 2 == 0:
+            raise ValueError("Only even number of layers allowed at the moment")
+        super().__init__(layers=layers, **kwargs)
+        _node_batch_norms = []
+        _edge_batch_norms = []
+        for _ in range(len(layers)):
+            if add_bn:
+                _node_batch_norms.append(nn.BatchNorm1d(node_dim))
+                _edge_batch_norms.append(nn.BatchNorm1d(edge_dim))
+            else:
+                _node_batch_norms.append(nn.Identity())
+                _edge_batch_norms.append(nn.Identity())
+        self._node_batch_norms = nn.ModuleList(_node_batch_norms)
+        self._edge_batch_norms = nn.ModuleList(_edge_batch_norms)
+
+    def _forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
+        xs = [x]
+        edge_attrs = [edge_attr]
         for i_layer_pair in range(len(self._layers) // 2):
             i0 = 2 * i_layer_pair
             hidden_x, hidden_edge_attr = self._layers[i0](
@@ -152,4 +159,106 @@ class ResIN(nn.Module):
             edge_attr = convex_combination(
                 delta=delta_edge_attr, residue=edge_attr, alpha_residue=self._alpha_edge
             )
-        return x, edge_attr
+        return x, edge_attr, xs, edge_attrs
+
+
+class SkipTopResidualNetwork(ResidualNetwork):
+    def __init__(
+        self,
+        layers: list[nn.Module],
+        connect_to=1,
+        **kwargs,
+    ):
+        """Residual network with skip connections to the top layer.
+
+        Args:
+            layers: List of layers
+            connect_to: Layer to which to add the skip connection. 0 means to the
+                input, 1 means to the output of the first layer, etc.
+            **kwargs: Arguments to `ResidualNetwork`
+        """
+        assert connect_to <= len(layers)
+        super().__init__(layers=layers, **kwargs)
+        self._residual_layer = connect_to
+
+    def _forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
+        xs = [x]
+        edge_attrs = [edge_attr]
+        x_residue = None
+        edge_attr_residue = None
+        for i_layer in range(len(self._layers)):
+            if i_layer == self._residual_layer:
+                x_residue = x
+                edge_attr_residue = edge_attr
+            delta_x, delta_edge_attr = self._layers[i_layer](x, edge_index, edge_attr)
+            x = convex_combination(
+                delta=relu(delta_x), residue=x_residue, alpha_residue=self._alpha_node
+            )
+            edge_attr = convex_combination(
+                delta=relu(delta_edge_attr),
+                residue=edge_attr_residue,
+                alpha_residue=self._alpha_edge,
+            )
+            xs.append(x)
+            edge_attrs.append(edge_attr)
+        return x, edge_attr, xs, edge_attrs
+
+
+RESIDUALNETWORKS_BY_NAME: dict[str, Any] = {
+    "skip1": Skip1ResidualNetwork,
+    "skip2": Skip2ResidualNetwork,
+    "skip_top": SkipTopResidualNetwork,
+}
+
+
+def build_resin(
+    *,
+    node_dim: int,
+    edge_dim: int,
+    object_hidden_dim=40,
+    relational_hidden_dim=40,
+    alpha_node: float = 0.5,
+    alpha_edge: float = 0.5,
+    n_layers=1,
+    residual_type: str = "skip1",
+    residual_kwargs: dict | None = None,
+) -> ResidualNetwork:
+    """Create a ResIN with identical layers of interaction networks
+
+    Args:
+        node_dim: Node feature dimension
+        edge_dim: Edge feature dimension
+        object_hidden_dim: Hidden dimension for the object model MLP
+        relational_hidden_dim: Hidden dimension for the relational model MLP
+        alpha_node: Strength of the node residual connection
+        alpha_edge: Strength of the edge residual connection
+        n_layers: Total number of layers
+        residual_type: Type of residual network. Options are 'skip1', 'skip2'.
+        residual_kwargs: Additional arguments to the residual network (can depend on
+            the residual type)
+    """
+    if residual_kwargs is None:
+        residual_kwargs = {}
+    layers = [
+        InteractionNetwork(
+            node_indim=node_dim,
+            edge_indim=edge_dim,
+            node_outdim=node_dim,
+            edge_outdim=edge_dim,
+            node_hidden_dim=object_hidden_dim,
+            edge_hidden_dim=relational_hidden_dim,
+        )
+        for _ in range(n_layers)
+    ]
+
+    if residual_type == "skip2":
+        residual_kwargs["node_dim"] = node_dim
+        residual_kwargs["edge_dim"] = edge_dim
+
+    mod = RESIDUALNETWORKS_BY_NAME[residual_type](
+        layers,
+        alpha_node=alpha_node,
+        alpha_edge=alpha_edge,
+        **residual_kwargs,
+    )
+    return mod

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -51,6 +51,7 @@ class ResidualNetwork(ABC, nn.Module):
         """Apply a list of layers in sequence with residual connections for the nodes.
         This is an abstract base class that does not contain code for the type of
         residual connections.
+
         Use one of the subclasses below.
 
         Args:
@@ -59,7 +60,7 @@ class ResidualNetwork(ABC, nn.Module):
             alpha_edge: Strength of the edge embedding residual connection
         """
         super().__init__()
-        self._layers = nn.ModuleList(layers)
+        self.layers = nn.ModuleList(layers)
         self._alpha_node = alpha_node
         self._alpha_edge = alpha_edge
 
@@ -87,7 +88,7 @@ class Skip1ResidualNetwork(ResidualNetwork):
     def _forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
         xs = [x]
         edge_attrs = [edge_attr]
-        for layer in self._layers:
+        for layer in self.layers:
             delta_x, delta_edge_attr = layer(x, edge_index, edge_attr)
             x = convex_combination(
                 delta=relu(delta_x),
@@ -141,15 +142,15 @@ class Skip2ResidualNetwork(ResidualNetwork):
     def _forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
         xs = [x]
         edge_attrs = [edge_attr]
-        for i_layer_pair in range(len(self._layers) // 2):
+        for i_layer_pair in range(len(self.layers) // 2):
             i0 = 2 * i_layer_pair
-            hidden_x, hidden_edge_attr = self._layers[i0](
+            hidden_x, hidden_edge_attr = self.layers[i0](
                 relu(self._node_batch_norms[i0](x)),
                 edge_index,
                 relu(self._edge_batch_norms[i0](edge_attr)),
             )
             i1 = 2 * i_layer_pair + 1
-            delta_x, delta_edge_attr = self._layers[i1](
+            delta_x, delta_edge_attr = self.layers[i1](
                 relu(self._node_batch_norms[i1](hidden_x)),
                 edge_index,
                 relu(self._edge_batch_norms[i1](hidden_edge_attr)),
@@ -189,11 +190,11 @@ class SkipTopResidualNetwork(ResidualNetwork):
         edge_attrs = [edge_attr]
         x_residue = None
         edge_attr_residue = None
-        for i_layer in range(len(self._layers)):
+        for i_layer in range(len(self.layers)):
             if i_layer == self._residual_layer:
                 x_residue = x
                 edge_attr_residue = edge_attr
-            delta_x, delta_edge_attr = self._layers[i_layer](x, edge_index, edge_attr)
+            delta_x, delta_edge_attr = self.layers[i_layer](x, edge_index, edge_attr)
             x = convex_combination(
                 delta=relu(delta_x), residue=x_residue, alpha_residue=self._alpha_node
             )
@@ -214,54 +215,81 @@ RESIDUALNETWORKS_BY_NAME: dict[str, Any] = {
 }
 
 
-def build_resin(
-    *,
-    node_dim: int,
-    edge_dim: int,
-    object_hidden_dim=40,
-    relational_hidden_dim=40,
-    alpha_node: float = 0.5,
-    alpha_edge: float = 0.5,
-    n_layers=1,
-    residual_type: str = "skip1",
-    residual_kwargs: dict | None = None,
-) -> ResidualNetwork:
-    """Create a ResIN with identical layers of interaction networks
+class ResIN(nn.Module):
+    def __init__(
+        self,
+        *,
+        node_dim: int,
+        edge_dim: int,
+        object_hidden_dim=40,
+        relational_hidden_dim=40,
+        alpha_node: float = 0.5,
+        alpha_edge: float = 0.5,
+        n_layers=1,
+        residual_type: str = "skip1",
+        residual_kwargs: dict | None = None,
+    ):
+        """Create a ResIN with identical layers of interaction networks
 
-    Args:
-        node_dim: Node feature dimension
-        edge_dim: Edge feature dimension
-        object_hidden_dim: Hidden dimension for the object model MLP
-        relational_hidden_dim: Hidden dimension for the relational model MLP
-        alpha_node: Strength of the node residual connection
-        alpha_edge: Strength of the edge residual connection
-        n_layers: Total number of layers
-        residual_type: Type of residual network. Options are 'skip1', 'skip2'.
-        residual_kwargs: Additional arguments to the residual network (can depend on
-            the residual type)
-    """
-    if residual_kwargs is None:
-        residual_kwargs = {}
-    layers = [
-        InteractionNetwork(
-            node_indim=node_dim,
-            edge_indim=edge_dim,
-            node_outdim=node_dim,
-            edge_outdim=edge_dim,
-            node_hidden_dim=object_hidden_dim,
-            edge_hidden_dim=relational_hidden_dim,
+        Args:
+            node_dim: Node feature dimension
+            edge_dim: Edge feature dimension
+            object_hidden_dim: Hidden dimension for the object model MLP
+            relational_hidden_dim: Hidden dimension for the relational model MLP
+            alpha_node: Strength of the node residual connection
+            alpha_edge: Strength of the edge residual connection
+            n_layers: Total number of layers
+            residual_type: Type of residual network. Options are 'skip1', 'skip2'.
+            residual_kwargs: Additional arguments to the residual network (can depend on
+                the residual type)
+        """
+        super().__init__()
+        if residual_kwargs is None:
+            residual_kwargs = {}
+        layers = [
+            InteractionNetwork(
+                node_indim=node_dim,
+                edge_indim=edge_dim,
+                node_outdim=node_dim,
+                edge_outdim=edge_dim,
+                node_hidden_dim=object_hidden_dim,
+                edge_hidden_dim=relational_hidden_dim,
+            )
+            for _ in range(n_layers)
+        ]
+
+        if residual_type == "skip2":
+            residual_kwargs["node_dim"] = node_dim
+            residual_kwargs["edge_dim"] = edge_dim
+
+        network = RESIDUALNETWORKS_BY_NAME[residual_type](
+            layers,
+            alpha_node=alpha_node,
+            alpha_edge=alpha_edge,
+            **residual_kwargs,
         )
-        for _ in range(n_layers)
-    ]
+        self.network = network
+        self.node_dim = node_dim
+        self.edge_dim = edge_dim
+        self._residual_type = residual_type
 
-    if residual_type == "skip2":
-        residual_kwargs["node_dim"] = node_dim
-        residual_kwargs["edge_dim"] = edge_dim
+    @property
+    def concat_node_embeddings_length(self) -> int:
+        """Length of the concatenated node embeddings from all intermediate layers.
+        Or in other words: `self.forward()[2].shape[1]`
+        """
+        if self._residual_type == "skip2":
+            return self.node_dim * (len(self.network.layers) // 2 + 1)
+        return self.node_dim * (len(self.network.layers) + 1)
 
-    mod = RESIDUALNETWORKS_BY_NAME[residual_type](
-        layers,
-        alpha_node=alpha_node,
-        alpha_edge=alpha_edge,
-        **residual_kwargs,
-    )
-    return mod
+    @property
+    def concat_edge_embeddings_length(self) -> int:
+        """Length of the concatenated edge embeddings from all intermediate layers.
+        Or in other words: `self.forward()[3].shape[1]`
+        """
+        if self._residual_type == "skip2":
+            return self.edge_dim * (len(self.network.layers) // 2 + 1)
+        return self.edge_dim * (len(self.network.layers) + 1)
+
+    def forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
+        return self.network.forward(x, edge_index, edge_attr)

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -112,7 +112,7 @@ class Skip2ResidualNetwork(ResidualNetwork):
         *,
         node_dim: int,
         edge_dim: int,
-        add_bn: bool = True,
+        add_bn: bool = False,
         **kwargs,
     ):
         """Residual network with skip connections every two layers.

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import math
-
 import torch
 from torch import Tensor
 from torch import Tensor as T
@@ -9,31 +7,20 @@ from torch import nn
 from torch.nn.functional import relu
 
 from gnn_tracking.models.interaction_network import InteractionNetwork
-from gnn_tracking.models.mlp import MLP
 
 
 @torch.jit.script
-def _convex_combination(*, delta: T, residue: T, alpha_residue: float) -> T:
-    return alpha_residue * residue + (1 - alpha_residue) * relu(delta)
-
-
-_IDENTITY = nn.Identity()
-
-
 def convex_combination(
     *,
     delta: T,
     residue: T,
     alpha_residue: float,
-    residue_encoder: nn.Module = _IDENTITY,
 ) -> T:
-    """Convex combination of ``relu(delta)`` and the residue."""
-    if math.isclose(alpha_residue, 0.0):
-        return relu(delta)
+    """Convex combination of delta and residue"""
+    # if torch.isclose(alpha_residue, 0.0):
+    #     return relu(delta)
     assert 0 <= alpha_residue <= 1
-    return _convex_combination(
-        delta=delta, residue=residue_encoder(residue), alpha_residue=alpha_residue
-    )
+    return alpha_residue * residue + (1 - alpha_residue) * delta
 
 
 class ResIN(nn.Module):
@@ -41,8 +28,11 @@ class ResIN(nn.Module):
         self,
         layers: list[nn.Module],
         *,
-        length_concatenated_edge_attrs: int,
-        alpha: float = 0.5,
+        node_dim: int,
+        edge_dim: int,
+        alpha_node: float = 0.5,
+        alpha_edge: float = 0.5,
+        add_bn: bool = True,
     ):
         """Apply a list of layers in sequence with residual connections for the nodes.
         Built for interaction networks, but any network that returns a node feature
@@ -54,47 +44,46 @@ class ResIN(nn.Module):
 
         Args:
             layers: List of layers
-            length_concatenated_edge_attrs: Length of the concatenated edge attributes
-                (from all the different layers)
-            alpha: Strength of the node embedding residual connection
+            node_dim: Node feature dimension
+            edge_dim: Edge feature dimension
+            alpha_node: Strength of the node embedding residual connection
+            alpha_edge: Strength of the edge embedding residual connection
+            add_bn: Add batch norms
         """
         super().__init__()
+        if not len(layers) % 2 == 0:
+            raise ValueError("Only even number of layers allowed at the moment")
         self._layers = nn.ModuleList(layers)
-        self._alpha = alpha
-        #: Because of the residual connections, we need map the output of the previous
-        #: layer to the dimension of the next layer (if they are different). This
-        #: can be done with these encoders.
-        self._residue_node_encoders = nn.ModuleList([nn.Identity() for _ in layers])
-        self.length_concatenated_edge_attrs = length_concatenated_edge_attrs
+        if add_bn:
+            self._node_batch_norms = nn.ModuleList(
+                [nn.BatchNorm1d(node_dim) for _ in range(len(layers))]
+            )
+            self._edge_batch_norms = nn.ModuleList(
+                [nn.BatchNorm1d(edge_dim) for _ in range(len(layers))]
+            )
+        else:
+            self._node_batch_norms = nn.ModuleList(
+                [nn.Identity() for _ in range(len(layers))]
+            )
+            self._edge_batch_norms = nn.ModuleList(
+                [nn.Identity() for _ in range(len(layers))]
+            )
 
-    @staticmethod
-    def _get_residue_encoder(
-        *, in_dim: int, out_dim: int, hidden_dim: int
-    ) -> nn.Module:
-        if in_dim == out_dim:
-            return nn.Identity()
-        return MLP(
-            input_size=in_dim,
-            output_size=out_dim,
-            hidden_dim=hidden_dim,
-            include_last_activation=True,
-            L=2,
-        )
+        self._alpha_node = alpha_node
+        self._alpha_edge = alpha_edge
 
     @classmethod
     def identical_in_layers(
         cls,
         *,
-        node_indim: int,
-        edge_indim: int,
-        node_hidden_dim: int,
-        edge_hidden_dim: int,
-        node_outdim=3,
-        edge_outdim=4,
+        node_dim: int,
+        edge_dim: int,
         object_hidden_dim=40,
         relational_hidden_dim=40,
-        alpha: float = 0.5,
+        alpha_node: float = 0.5,
+        alpha_edge: float = 0.5,
         n_layers=1,
+        **kwargs,
     ) -> ResIN:
         """Create a ResIN with identical layers of interaction networks except for
         the first and last one (different dimensions)
@@ -103,60 +92,37 @@ class ResIN(nn.Module):
         used to map the previous output for the residual connection.
 
         Args:
-            node_indim: Node feature dimension
-            edge_indim: Edge feature dimension
-            node_hidden_dim: Node feature dimension for the hidden layers
-            edge_hidden_dim: Edge feature dimension for the hidden layers
-            node_outdim: Output node feature dimension
-            edge_outdim: Output edge feature dimension
+            node_dim: Node feature dimension
+            edge_dim: Edge feature dimension
             object_hidden_dim: Hidden dimension for the object model MLP
             relational_hidden_dim: Hidden dimension for the relational model MLP
-            alpha: Strength of the residual connection
+            alpha_node: Strength of the node residual connection
+            alpha_edge: Strength of the edge residual connection
             n_layers: Total number of layers
+            **kwargs: Passed on to __init__
         """
-        node_dims = [
-            node_indim,
-            *[node_hidden_dim for _ in range(n_layers - 1)],
-            node_outdim,
-        ]
-        edge_dims = [
-            edge_indim,
-            *[edge_hidden_dim for _ in range(n_layers - 1)],
-            edge_outdim,
-        ]
-        assert len(node_dims) == len(edge_dims) == n_layers + 1
         layers = [
             InteractionNetwork(
-                node_indim=node_dims[i],
-                edge_indim=edge_dims[i],
-                node_outdim=node_dims[i + 1],
-                edge_outdim=edge_dims[i + 1],
+                node_indim=node_dim,
+                edge_indim=edge_dim,
+                node_outdim=node_dim,
+                edge_outdim=edge_dim,
                 node_hidden_dim=object_hidden_dim,
                 edge_hidden_dim=relational_hidden_dim,
             )
             for i in range(n_layers)
         ]
-        length_concatenated_edge_attrs = edge_hidden_dim * (n_layers - 1) + edge_outdim
         mod = cls(
             layers,
-            length_concatenated_edge_attrs=length_concatenated_edge_attrs,
-            alpha=alpha,
-        )
-        mod._residue_node_encoders = nn.ModuleList(
-            [
-                cls._get_residue_encoder(
-                    in_dim=node_dims[i],
-                    out_dim=node_dims[i + 1],
-                    hidden_dim=node_dims[i + 1],
-                )
-                for i in range(n_layers)
-            ]
+            alpha_node=alpha_node,
+            alpha_edge=alpha_edge,
+            node_dim=node_dim,
+            edge_dim=edge_dim,
+            **kwargs,
         )
         return mod
 
-    def forward(
-        self, x, edge_index, edge_attr
-    ) -> tuple[Tensor, list[Tensor], list[Tensor]]:
+    def forward(self, x, edge_index, edge_attr) -> tuple[Tensor, Tensor]:
         """Forward pass
 
         Args:
@@ -165,16 +131,25 @@ class ResIN(nn.Module):
             edge_attr: Edge features
 
         Returns:
-            node embedding, node embedding at each layer (including the input and
-            final node embedding), edge embedding at each layer (including the input)
+            node embedding, edge_embedding
         """
-        edge_attrs = [edge_attr]
-        xs = [x]
-        for layer, re in zip(self._layers, self._residue_node_encoders):
-            delta_x, edge_attr = layer(x, edge_index, edge_attr)
-            x = convex_combination(
-                delta=delta_x, residue=x, alpha_residue=self._alpha, residue_encoder=re
+        for i_layer_pair in range(len(self._layers) // 2):
+            i0 = 2 * i_layer_pair
+            hidden_x, hidden_edge_attr = self._layers[i0](
+                relu(self._node_batch_norms[i0](x)),
+                edge_index,
+                relu(self._edge_batch_norms[i0](edge_attr)),
             )
-            xs.append(x)
-            edge_attrs.append(edge_attr)
-        return x, xs, edge_attrs
+            i1 = 2 * i_layer_pair + 1
+            delta_x, delta_edge_attr = self._layers[i1](
+                relu(self._node_batch_norms[i1](hidden_x)),
+                edge_index,
+                relu(self._edge_batch_norms[i1](hidden_edge_attr)),
+            )
+            x = convex_combination(
+                delta=delta_x, residue=x, alpha_residue=self._alpha_node
+            )
+            edge_attr = convex_combination(
+                delta=delta_edge_attr, residue=edge_attr, alpha_residue=self._alpha_edge
+            )
+        return x, edge_attr

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -191,7 +191,7 @@ class SkipTopResidualNetwork(ResidualNetwork):
         return x, edge_attr, edge_attrs
 
 
-RESIDUALNETWORKS_BY_NAME: dict[str, Any] = {
+RESIDUAL_NETWORKS_BY_NAME: dict[str, Any] = {
     "skip1": Skip1ResidualNetwork,
     "skip2": Skip2ResidualNetwork,
     "skip_top": SkipTopResidualNetwork,
@@ -244,7 +244,7 @@ class ResIN(nn.Module):
             residual_kwargs["node_dim"] = node_dim
             residual_kwargs["edge_dim"] = edge_dim
 
-        network = RESIDUALNETWORKS_BY_NAME[residual_type](
+        network = RESIDUAL_NETWORKS_BY_NAME[residual_type](
             layers,
             alpha=alpha,
             **residual_kwargs,

--- a/src/gnn_tracking/models/resin.py
+++ b/src/gnn_tracking/models/resin.py
@@ -1,3 +1,5 @@
+"""Deep stacked interaction networks with residual connections"""
+
 from __future__ import annotations
 
 import math
@@ -52,7 +54,8 @@ class ResidualNetwork(ABC, nn.Module):
         This is an abstract base class that does not contain code for the type of
         residual connections.
 
-        Use one of the subclasses below.
+        Use one of the subclasses below or use `ResIN` (a convenience wrapper around
+        the subclasses for layers of identical INs).
 
         Args:
             layers: List of layers
@@ -85,6 +88,12 @@ class ResidualNetwork(ABC, nn.Module):
 
 
 class Skip1ResidualNetwork(ResidualNetwork):
+    def __init__(self, *args, **kwargs):
+        """A residual network in which any two successive layers are connected by a
+        residual connection.
+        """
+        super().__init__(*args, **kwargs)
+
     def _forward(self, x, edge_index, edge_attr) -> tuple[T, T, list[T], list[T]]:
         xs = [x]
         edge_attrs = [edge_attr]
@@ -115,7 +124,8 @@ class Skip2ResidualNetwork(ResidualNetwork):
         add_bn: bool = False,
         **kwargs,
     ):
-        """Residual network with skip connections every two layers.
+        """A residual network built from blocks of two layers. Each of these blocks
+        is connected to its predecessor by a residual connection.
 
         Args:
             layers: List of layers

--- a/src/gnn_tracking/models/test_edge_classifier.py
+++ b/src/gnn_tracking/models/test_edge_classifier.py
@@ -19,14 +19,14 @@ def test_perfect_edge_classification():
     pec = PerfectEdgeClassification()
     y = [True, False, True, False]
     d = MockData(y=y)
-    assert (pec.forward(d) == torch.Tensor(y)).all()
+    assert (pec.forward(d)["W"] == torch.Tensor(y)).all()
 
 
 def test_perfect_edge_classification_pt_thld():
     pec = PerfectEdgeClassification(false_below_pt=0.5)
     y = [True, False, True, False]
     d = MockData(y=y, pt=[0, 0, 1, 1])
-    assert (pec.forward(d) == torch.Tensor([False, False, True, False])).all()
+    assert (pec.forward(d)["W"] == torch.Tensor([False, False, True, False])).all()
 
 
 def test_perfect_edge_classification_tpr_tnr():
@@ -34,4 +34,4 @@ def test_perfect_edge_classification_tpr_tnr():
     y = torch.full((100,), True)
     d = MockData(y=y)
     pec = PerfectEdgeClassification(tpr=0.5)
-    assert 45 < pec.forward(d).sum() < 55
+    assert 45 < pec.forward(d)["W"].sum() < 55

--- a/src/gnn_tracking/models/track_condensation_networks.py
+++ b/src/gnn_tracking/models/track_condensation_networks.py
@@ -237,7 +237,7 @@ class ModularGraphTCN(nn.Module):
         # apply the track condenser
         h_hc = self.relu(self.hc_node_encoder(data.x))
         edge_attr_hc = self.relu(self.hc_edge_encoder(edge_attr))
-        h_hc, _, _, edge_attrs_hc = self.hc_in(h_hc, data.edge_index, edge_attr_hc)
+        h_hc, _, edge_attrs_hc = self.hc_in(h_hc, data.edge_index, edge_attr_hc)
         beta = torch.sigmoid(self.p_beta(h_hc))
         # protect against nans
         beta = beta + torch.ones_like(beta) * 10e-9
@@ -297,7 +297,7 @@ class GraphTCN(nn.Module):
             interaction_node_dim=h_dim,
             interaction_edge_dim=e_dim,
             L_ec=L_ec,
-            alpha_ec_node=alpha_ec,
+            alpha=alpha_ec,
         )
         # Todo: Add other resin options
         hc_in = ResIN(
@@ -305,8 +305,7 @@ class GraphTCN(nn.Module):
             edge_dim=e_dim,
             object_hidden_dim=hidden_dim,
             relational_hidden_dim=hidden_dim,
-            alpha_node=alpha_hc,
-            alpha_edge=alpha_hc,
+            alpha=alpha_hc,
             n_layers=L_hc,
         )
         self._gtcn = ModularGraphTCN(
@@ -369,8 +368,7 @@ class PerfectECGraphTCN(nn.Module):
             edge_dim=e_dim,
             object_hidden_dim=hidden_dim,
             relational_hidden_dim=hidden_dim,
-            alpha_node=alpha_hc,
-            alpha_edge=alpha_hc,
+            alpha=alpha_hc,
             n_layers=L_hc,
         )
         self._gtcn = ModularGraphTCN(
@@ -428,8 +426,7 @@ class PreTrainedECGraphTCN(nn.Module):
             edge_dim=e_dim,
             object_hidden_dim=hidden_dim,
             relational_hidden_dim=hidden_dim,
-            alpha_node=alpha_hc,
-            alpha_edge=alpha_hc,
+            alpha=alpha_hc,
             n_layers=L_hc,
         )
         self._gtcn = ModularGraphTCN(

--- a/src/gnn_tracking/models/track_condensation_networks.py
+++ b/src/gnn_tracking/models/track_condensation_networks.py
@@ -12,7 +12,7 @@ from gnn_tracking.models.dynamic_edge_conv import DynamicEdgeConv
 from gnn_tracking.models.edge_classifier import ECForGraphTCN, PerfectEdgeClassification
 from gnn_tracking.models.interaction_network import InteractionNetwork as IN
 from gnn_tracking.models.mlp import MLP
-from gnn_tracking.models.resin import build_resin
+from gnn_tracking.models.resin import ResIN
 from gnn_tracking.utils.graph_masks import edge_subgraph
 
 
@@ -300,7 +300,7 @@ class GraphTCN(nn.Module):
             alpha_ec=alpha_ec,
         )
         # Todo: Add other resin options
-        hc_in = build_resin(
+        hc_in = ResIN(
             node_dim=h_dim,
             edge_dim=e_dim,
             object_hidden_dim=hidden_dim,
@@ -364,7 +364,7 @@ class PerfectECGraphTCN(nn.Module):
         """
         super().__init__()
         ec = PerfectEdgeClassification(tpr=ec_tpr, tnr=ec_tnr)
-        hc_in = build_resin(
+        hc_in = ResIN(
             node_dim=h_dim,
             edge_dim=e_dim,
             object_hidden_dim=hidden_dim,
@@ -423,7 +423,7 @@ class PreTrainedECGraphTCN(nn.Module):
                 networks
         """
         super().__init__()
-        hc_in = build_resin(
+        hc_in = ResIN(
             node_dim=h_dim,
             edge_dim=e_dim,
             object_hidden_dim=hidden_dim,

--- a/src/gnn_tracking/models/track_condensation_networks.py
+++ b/src/gnn_tracking/models/track_condensation_networks.py
@@ -297,7 +297,7 @@ class GraphTCN(nn.Module):
             interaction_node_dim=h_dim,
             interaction_edge_dim=e_dim,
             L_ec=L_ec,
-            alpha_ec=alpha_ec,
+            alpha_ec_node=alpha_ec,
         )
         # Todo: Add other resin options
         hc_in = ResIN(

--- a/src/gnn_tracking/models/track_condensation_networks.py
+++ b/src/gnn_tracking/models/track_condensation_networks.py
@@ -305,8 +305,8 @@ class GraphTCN(nn.Module):
             h_dim=h_dim,
             e_dim=e_dim,
             hidden_dim=hidden_dim,
-            interaction_node_hidden_dim=interaction_node_hidden_dim,
-            interaction_edge_hidden_dim=interaction_edge_hidden_dim,
+            interaction_node_dim=interaction_node_hidden_dim,
+            interaction_edge_dim=interaction_edge_hidden_dim,
             L_ec=L_ec,
             alpha_ec=alpha_ec,
         )

--- a/src/gnn_tracking/models/track_condensation_networks.py
+++ b/src/gnn_tracking/models/track_condensation_networks.py
@@ -157,7 +157,7 @@ class ModularGraphTCN(nn.Module):
         mask_orphan_nodes=False,
     ):
         """General form of track condensation network based on preconstructed graphs
-        with initial step of edge classification.
+        with initial step of edge classification (passed as a parameter).
 
         Args:
             ec: Edge classifier
@@ -215,7 +215,7 @@ class ModularGraphTCN(nn.Module):
         data: Data,
     ) -> dict[str, Tensor]:
         # Assign it to the data object, so that the cuts will be applied to it as well
-        data.edge_weights = self.ec(data)
+        data.edge_weights = self.ec(data)["W"]
         edge_weights_unmasked = data.edge_weights.clone().detach()
         edge_mask = (data.edge_weights > self.threshold).squeeze()
         data = edge_subgraph(data, edge_mask)

--- a/src/gnn_tracking/models/track_condensation_networks.py
+++ b/src/gnn_tracking/models/track_condensation_networks.py
@@ -161,8 +161,7 @@ class ModularGraphTCN(nn.Module):
 
         Args:
             ec: Edge classifier
-            hc_in: Track condensor interaction network. Must have the
-                ``length_concatenated_edge_attrs`` attribute (see `ResIN` module)
+            hc_in: Track condensor interaction network.
             node_indim: Node feature dimension
             edge_indim: Edge feature dimension
             h_dim: node dimension in the condensation interaction networks
@@ -271,7 +270,7 @@ class GraphTCN(nn.Module):
         alpha_hc: float = 0.5,
         feed_edge_weights=False,
     ):
-        """Particular implementation of `ModularTCN` with `ECForGraphTCN` as
+        """`ModularTCN` with `ECForGraphTCN` as
         edge classification step and several interaction networks as residual layers
         for the track condensor network.
 

--- a/src/gnn_tracking/test_training_integration.py
+++ b/src/gnn_tracking/test_training_integration.py
@@ -42,6 +42,14 @@ _test_train_test_cases = [
     ),
     TestTrainCase(
         "pretrainedec",
+        ec_params=dict(residual_type="skip2"),
+    ),
+    TestTrainCase(
+        "pretrainedec",
+        ec_params=dict(residual_type="skip_top"),
+    ),
+    TestTrainCase(
+        "pretrainedec",
         ec_params=dict(use_intermediate_layers=False),
     ),
     TestTrainCase(

--- a/src/gnn_tracking/test_training_integration.py
+++ b/src/gnn_tracking/test_training_integration.py
@@ -50,7 +50,7 @@ _test_train_test_cases = [
     ),
     TestTrainCase(
         "pretrainedec",
-        ec_params=dict(use_intermediate_layers=False),
+        ec_params=dict(use_intermediate_encodings=False),
     ),
     TestTrainCase(
         "perfectec",

--- a/src/gnn_tracking/test_training_integration.py
+++ b/src/gnn_tracking/test_training_integration.py
@@ -50,7 +50,11 @@ _test_train_test_cases = [
     ),
     TestTrainCase(
         "pretrainedec",
-        ec_params=dict(use_intermediate_encodings=False),
+        ec_params=dict(use_intermediate_edge_embeddings=False),
+    ),
+    TestTrainCase(
+        "pretrainedec",
+        ec_params=dict(use_intermediate_edge_embeddings=False),
     ),
     TestTrainCase(
         "perfectec",

--- a/src/gnn_tracking/test_training_integration.py
+++ b/src/gnn_tracking/test_training_integration.py
@@ -54,7 +54,13 @@ _test_train_test_cases = [
     ),
     TestTrainCase(
         "pretrainedec",
-        ec_params=dict(use_intermediate_edge_embeddings=False),
+        ec_params=dict(
+            use_intermediate_edge_embeddings=False, use_node_embedding=False
+        ),
+    ),
+    TestTrainCase(
+        "pretrainedec",
+        ec_params=dict(use_node_embedding=False),
     ),
     TestTrainCase(
         "perfectec",

--- a/src/gnn_tracking/test_training_integration.py
+++ b/src/gnn_tracking/test_training_integration.py
@@ -23,10 +23,13 @@ class TestTrainCase:
     model: str = "graphtcn"
     loss_weights: str = "default"
     ec_params: dict[str, Any] | None = None
+    tc_params: dict[str, Any] | None = None
 
     def __post_init__(self):
         if self.ec_params is None:
             self.ec_params = {}
+        if self.tc_params is None:
+            self.tc_params = {}
 
 
 _test_train_test_cases = [
@@ -36,6 +39,14 @@ _test_train_test_cases = [
     TestTrainCase("graphtcn", loss_weights="auto"),
     TestTrainCase(
         "graphtcn",
+    ),
+    TestTrainCase(
+        "graphtcn",
+        tc_params=dict(mask_orphan_nodes=True),
+    ),
+    TestTrainCase(
+        "graphtcn",
+        tc_params=dict(mask_orphan_nodes=True, use_ec_embeddings_for_hc=True),
     ),
     TestTrainCase(
         "pretrainedec",
@@ -61,6 +72,10 @@ _test_train_test_cases = [
     TestTrainCase(
         "pretrainedec",
         ec_params=dict(use_node_embedding=False),
+    ),
+    TestTrainCase(
+        "pretrainedec",
+        tc_params=dict(use_ec_embeddings_for_hc=True),
     ),
     TestTrainCase(
         "perfectec",
@@ -102,6 +117,7 @@ def test_train(tmp_path, built_graphs, t: TestTrainCase) -> None:
             hidden_dim=2,
             L_ec=2,
             L_hc=2,
+            **t.tc_params,
         )
     elif t.model == "pretrainedec":
         ec = ECForGraphTCN(
@@ -117,6 +133,7 @@ def test_train(tmp_path, built_graphs, t: TestTrainCase) -> None:
             edge_indim=edge_indim,
             hidden_dim=2,
             L_hc=2,
+            **t.tc_params,
         )
     elif t.model == "perfectec":
         model = PerfectECGraphTCN(
@@ -126,6 +143,7 @@ def test_train(tmp_path, built_graphs, t: TestTrainCase) -> None:
             L_hc=2,
             ec_tpr=0.8,
             ec_tnr=0.4,
+            **t.tc_params,
         )
     else:
         raise ValueError(f"Unknown model type {t.model}")

--- a/src/gnn_tracking/test_training_integration.py
+++ b/src/gnn_tracking/test_training_integration.py
@@ -41,6 +41,10 @@ _test_train_test_cases = [
         "pretrainedec",
     ),
     TestTrainCase(
+        "pretrainedec",
+        ec_params=dict(use_intermediate_layers=False),
+    ),
+    TestTrainCase(
         "perfectec",
     ),
 ]


### PR DESCRIPTION
General changes:

* Different output for ECs: Now return dictionary with `W` holding the weight

New flags for `ECForGraphTCN`:

* `use_node_embedding`: concat node features for `W` prediction
* `use_intermediate_edge_embeddings`: 
* Options to change residual connections 

Changed flags: 

* There is only one e/n dimension for the INs
* `alpha` instead of `alpha_ec`

Residual networks

* Residual connections now independent independent of INs
* Still have `ResIn` class that servers as convenience class

Remaining tasks

* [ ] `depth` or `L` instead of `L_ec`?