### PR TITLE
Fixes and changes to definition of residual networks

### DIFF
--- a/src/gnn_tracking/models/graph_construction.py
+++ b/src/gnn_tracking/models/graph_construction.py
@@ -43,7 +43,7 @@ class GraphConstructionFCNN(nn.Module, HyperparametersMixin):
             hidden_dim: Hidden dimension
             out_dim: Output dimension = embedding space
             depth: Number of layers
-            beta: Strength of residual connections
+            beta: 1-Strength of residual connection
         """
 
         super().__init__()


### PR DESCRIPTION
1. Change: "Squared" combination instead of convex combination
2. Fix: ReLU also applied to edge attributes
3. Fix: SkipTopNetwork when not connecting to top layer
